### PR TITLE
Allow setting proxy target via environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,9 @@ FROM node:4-onbuild
 RUN echo 'edgemicro:\n\
   logging:\n\
     level: warn\n\
-proxies:\n\
-- base_path: /\n\
-  # put a target URL here (or leave blank for dummy target server)\n\
-  url:\n\
+headers:\n\
+  # Retain the originally requested Host header\n\
+  host: false\n\
 ' > /usr/src/app/config/default.yaml
 
 EXPOSE 3000

--- a/bin/sso-proxy.js
+++ b/bin/sso-proxy.js
@@ -5,6 +5,7 @@
 const proxy = require('../test/helpers/proxy')
 const config = require('config')
 const superagent = require('superagent')
+const utils = require('./utils')
 
 // make this work in Passenger even if creating a fake target
 // see: https://www.phusionpassenger.com/library/indepth/nodejs/reverse_port_binding.html
@@ -13,14 +14,23 @@ if (typeof(PhusionPassenger) !== 'undefined' && !config.proxies[0].url) {
   config.edgemicro.port = 'passenger'
 }
 
-getPublicKey()
+utils.getPublicKey(config)
   .then(publicKey => {
     config.sso.public_key = publicKey
-    return getTarget()
+    return getTarget(config)
   })
   .then(target => {
     console.log(`proxy target: ${target}`)
-    config.proxies[0].url = target
+    // If there isn't already a proxy configured, configure one with a default base_path of /.  Otherwise, update the
+    // first proxy with the provided target.
+    if (!config.proxies[0]) {
+      config.proxies[0] = {
+        base_path: '/',
+        url: target
+      }
+    } else {
+      config.proxies[0].url = target
+    }
     return proxy.start(config, target)
   })
   .then(server => {
@@ -32,34 +42,33 @@ getPublicKey()
     process.exit(1)
   })
 
+function getTarget (config) {
+  // Ensure that config.proxies is set to something to avoid validating it below
+  if (!config.proxies) {
+    config.proxies = []
+  }
 
-function getTarget() {
   return new Promise((resolve, reject) => {
-    if (config.proxies[0].url) return resolve(config.proxies[0].url)
+    // Either use a pre-provided proxy, get the proxy details from the SSO_PROXY_TARGET environment variable or use the
+    // dummy target. (In the case of bin/target.js, we will always use the dummy target.)
+    if (config.proxies[0] && config.proxies[0].url) {
+      resolve(config.proxies[0].url)
+    } else if (process.env.SSO_PROXY_TARGET) {
+      const proxyParts = process.env.SSO_PROXY_TARGET.split('->')
 
-    const keys = { publicKey: config.sso.public_key }
-    return require('../test/helpers/target')
-      .start(keys)
-      .then(target => {
-        console.log('started dummy target')
-        resolve(`http://localhost:${target.address().port}`)
-      })
-      .catch(err => {
-        reject(err)
-      })
-  })
-}
-
-function getPublicKey() {
-  return new Promise((resolve, reject) => {
-    if (config.sso.public_key) return resolve(config.sso.public_key)
-
-    superagent
-      .get(config.sso.public_key_url)
-      .end((err, res) => {
-        if (err) return reject(err)
-        if (!res.body.value) return reject(`Unable to retrieve public key from: ${config.sso.public_key_url}`)
-        resolve(res.body.value)
-      })
+      if (proxyParts.length !== 2) {
+        reject('Invalid SSO_PROXY_TARGET value.  Expected format: {BASE_PATH}->{URL}')
+      } else {
+        // Prepend the proxy to ensure that it gets used
+        config.proxies.unshift({
+          base_path: proxyParts[0].trim(),
+          url: proxyParts[1].trim()
+        })
+        resolve(config.proxies[0].url)
+      }
+    } else {
+      utils.startDummyTarget(config)
+        .then(resolve, reject)
+    }
   })
 }

--- a/bin/utils.js
+++ b/bin/utils.js
@@ -1,0 +1,39 @@
+'use strict'
+
+const superagent = require('superagent')
+const target = require('../test/helpers/target')
+
+module.exports.getPublicKey = (config) => {
+  return new Promise((resolve, reject) => {
+    if (config.sso.public_key) {
+      resolve(config.sso.public_key)
+    } else {
+      superagent
+        .get(config.sso.public_key_url)
+        .end((err, res) => {
+          if (err) {
+            reject(err)
+          } else if (!res.body.value) {
+            reject(`Unable to retrieve public key from: ${config.sso.public_key_url}`)
+          } else {
+            resolve(res.body.value)
+          }
+        })
+    }
+  })
+}
+
+module.exports.startDummyTarget = (config, dummyPort) => {
+  return new Promise((resolve, reject) => {
+    target.start({
+      publicKey: config.sso.public_key
+    }, dummyPort)
+      .then(target => {
+        console.log('started dummy target')
+        resolve(`http://localhost:${target.address().port}`)
+      })
+      .catch(err => {
+        reject(err)
+      })
+  })
+}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "debug": "^2.2.0",
     "js-yaml": "^3.5.3",
     "jsonwebtoken": "^5.5.4",
-    "microgateway-core": "^2.0.14",
+    "microgateway-core": "^2.0.15",
     "mkdirp": "^0.5.1",
     "passport": "^0.3.2",
     "passport-oauth": "^1.0.0",


### PR DESCRIPTION
The purpose of this commit was to update the `bin/sso-proxy.js` wrapper
to allow you to set the pass-through proxy target via an environment
variable.  During this there was some refactoring done to combine common
code used in both wrappers in `bin/`.  _(I realize this is mixing
concerns but during testing there were issues related to missing
`config.proxies` configurations and they were resolved during this
refactoring.)_

After this commit, you can set `SSO_PROXY_TARGET` via pattern
`{BASE_PATH}->{URL}` to create a proxy configuration at
`config.proxies[0]`.  The `Dockerfile` was also updated to benefit from
the refactoring by removing the broken shim proxy configuration.
