### PR TITLE
Plugin signature updates

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -78,9 +78,9 @@ module.exports = function init(config, logger, stats) {
   }
 
   // plugin handler
-  function onresponse(req, res, data, next) {
+  function onresponse(req, res, targetResponse, data, next) {
 
-    if (data.targetResponse.statusCode !== 401) return next()
+    if (targetResponse.statusCode !== 401) return next()
 
     debug('invalid auth, start oauth flow')
     const callback = encodeURIComponent(config.oauth.callbackURL)
@@ -89,7 +89,7 @@ module.exports = function init(config, logger, stats) {
     // do a 401 redirect
     let redirectUrl = `${config.oauth.authorizationURL}?response_type=code&redirect_uri=${callback}&client_id=${clientId}`
     if (req.method === 'GET') {
-      const restartUrl = req.headers[restartUrlHeader] || data.targetResponse.headers[restartUrlHeader] || req.url
+      const restartUrl = req.headers[restartUrlHeader] || targetResponse.headers[restartUrlHeader] || req.url
       const state = encodeURIComponent(restartUrl)
       redirectUrl += `&state=${state}`
     }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "debug": "^2.2.0",
     "js-yaml": "^3.5.3",
     "jsonwebtoken": "^5.5.4",
-    "microgateway-core": "^2.0.15",
+    "microgateway-core": "^2.3.3-beta",
     "mkdirp": "^0.5.1",
     "passport": "^0.3.2",
     "passport-oauth": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "debug": "^2.2.0",
     "js-yaml": "^3.5.3",
     "jsonwebtoken": "^5.5.4",
-    "microgateway-core": "^2.3.3-beta",
+    "microgateway-core": "^2.3.2-beta",
     "mkdirp": "^0.5.1",
     "passport": "^0.3.2",
     "passport-oauth": "^1.0.0",


### PR DESCRIPTION
`microgateway-core` was updated a while ago, and changed the way plugins are called. It was updated to make the way plugins work consistent with documentation. We've added a new plugin function signature to take advantage of reading a response from a target instead of accessing through the data object.

This PR updates the sso proxy to take advantage of the new signature. 