### PR TITLE
Add /sessioninfo endpoint

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -73,7 +73,10 @@ module.exports = function init(config, logger, stats) {
       })
     } else if (req.method === 'GET' && req.reqUrl.pathname === '/sessioninfo') {
       // Session info request
-      checkToken(req, res, function() {
+      checkToken(req, res, function(err) {
+        if (err) return sendError(req, res, 500, err);
+        if (!req.parsedToken) return sendError(req, res, 401, 'missing authorization token');
+
         var sessionInfo = {
           aud: req.parsedToken.aud,
           client_id: req.parsedToken.client_id,

--- a/lib/index.js
+++ b/lib/index.js
@@ -71,6 +71,23 @@ module.exports = function init(config, logger, stats) {
         res.writeHead(302, { location: redirectPath })
         res.end()
       })
+    } else if (req.method === 'GET' && req.reqUrl.pathname === '/sessioninfo') {
+      // Session info request
+      checkToken(req, res, function() {
+        var sessionInfo = {
+          aud: req.parsedToken.aud,
+          client_id: req.parsedToken.client_id,
+          email: req.parsedToken.email,
+          iss: req.parsedToken.iss,
+          origin: req.parsedToken.origin,
+          scope: req.parsedToken.scope,
+          user_id: req.parsedToken.user_id,
+          user_name: req.parsedToken.user_name
+        };
+
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(sessionInfo));
+      });
     } else {
       // normal request
       checkToken(req, res, next)
@@ -138,6 +155,7 @@ module.exports = function init(config, logger, stats) {
     verifyJWT(token)
       .then(parsedToken => {
         debug('valid token %o', parsedToken)
+        req.parsedToken = parsedToken
         setDownstreamHeaders(req, token)
         next()
       })

--- a/test/index.js
+++ b/test/index.js
@@ -352,11 +352,47 @@ describe('oauth-proxy', () => {
     })
   })
 
+  describe('/sessioninfo', function() {
+
+    it('should allow valid access token in authorization header to access endpoint', function(done) {
+      const token = createJWTToken(this.keys);
+      request(this.server)
+        .get('/sessioninfo')
+        .set('Authorization', `Bearer ${token}`)
+        .expect('Content-Type', /json/)
+        .expect(200, { email: 'example@example.com' })
+        .end(done)
+    })
+
+    it('should allow valid access token in cookie to access endpoint', function(done) {
+      const token = createJWTToken(this.keys);
+      var cookieHeader = cookie.serialize('access_token', token)
+      request(this.server)
+        .get('/sessioninfo')
+        .set('Cookie', cookieHeader)
+        .expect('Content-Type', /json/)
+        .expect(200, { email: 'example@example.com' })
+        .end(done)
+    })
+
+    it('should reject invalid authorization header', function(done) {
+      request(this.server)
+        .get('/sessioninfo')
+        .set('Authorization', 'Like, whatever, man')
+        .expect(400)
+        .end(done)
+    })
+
+  })
+
 })
 
 function createJWTToken(keys, expiresIn, includeRefresh) {
   const options = { algorithm: 'RS256', expiresIn: expiresIn }
-  const payload = { test: 'test' }
+  const payload = {
+    test: 'test',
+    email: 'example@example.com'
+  }
   return jwt.sign(payload, keys.privateKey, options)
 }
 


### PR DESCRIPTION
Used by browser clients to get a user's scope/email/etc when the cookie is marked HTTP-only